### PR TITLE
fix(ci): add project alias for master branch

### DIFF
--- a/.firebaserc
+++ b/.firebaserc
@@ -1,6 +1,7 @@
 {
   "projects": {
     "default": "cv19assist-dev",
+    "master": "cv19assist-dev",
     "production": "cv19assist-bfa5f"
   }
 }


### PR DESCRIPTION
Adds the project alias for the master branch so that merging to `master` deploys to the `cv19assist-dev` project