### PR TITLE
Check version before creating new release

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -121,11 +121,12 @@ jobs:
           bin/updateEmailTemplates.js
 
       - name: Check if version has been updated
+        if: github.ref == 'refs/heads/production'
         id: check
         uses: EndBug/version-check@v1
 
       - name: Create Release
-        if: steps.check.outputs.changed == 'true'
+        if: github.ref == 'refs/heads/production' && steps.check.outputs.changed == 'true'
         id: create_release
         uses: actions/create-release@latest
         env:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -120,7 +120,12 @@ jobs:
           echo "Service Account selected for projectId $(echo $SERVICE_ACCOUNT | jq .project_id)"
           bin/updateEmailTemplates.js
 
+      - name: Check if version has been updated
+        id: check
+        uses: EndBug/version-check@v1
+
       - name: Create Release
+        if: steps.check.outputs.changed == 'true'
         id: create_release
         uses: actions/create-release@latest
         env:


### PR DESCRIPTION
### Description
* Prevent error in release stage of deploy workflow by checking version before creating new release

**NOTE**: If we want to skip deploying or any other logic if the version hasn't changed, we can move this logic up and add `if: steps.check.outputs.changed == 'true'` to any stages we want to skip. We can also skip all and have a clear message that the version hasn't change, and exit with an error, up to you @thebitguru. In my experience, the message and skipping everything else is most clear, but that requires a version change before deploy

### Relevant Tickets (Please add `closes`, `refs`, etc)

- closes #

### Screenshots (if appropriate)
