### PR TITLE
chore: switch notifications permissions deny from error to analytics event

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -120,6 +120,23 @@ jobs:
           echo "Service Account selected for projectId $(echo $SERVICE_ACCOUNT | jq .project_id)"
           bin/updateEmailTemplates.js
 
+      - name: Upload SourceMaps to Sentry
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: cv19-assist
+        run: |
+          version=$(cat package.json | jq  .version -r)
+          gitBranch=${GITHUB_REF##*/}
+          envName=$(if [ $gitBranch == "master" ]; then echo staging; else echo $gitBranch; fi;)
+          releaseSuffix=$envName@$version
+          releaseName=cv19assist-$releaseSuffix
+          export SENTRY_PROJECT=app
+          echo ""
+          echo Creating Sentry release \"$releaseName\" for project \"$SENTRY_PROJECT\"
+          $(yarn bin)/sentry-cli releases new $releaseName --finalize
+          echo Uploading source maps to Sentry
+          $(yarn bin)/sentry-cli releases files $releaseName upload-sourcemaps ./build/static/js --no-rewrite
+
       - name: Check if version has been updated
         if: github.ref == 'refs/heads/production'
         id: check

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
   },
   "devDependencies": {
     "@googlemaps/google-maps-services-js": "^2.6.0",
+    "@sentry/cli": "^1.52.3",
     "babel-eslint": "^10.0.3",
     "cross-env": "^7.0.2",
     "cypress": "^4.5.0",

--- a/src/components/SetupMessaging/useSetupMessaging.js
+++ b/src/components/SetupMessaging/useSetupMessaging.js
@@ -1,4 +1,4 @@
-import { useMessaging, useUser, useFirestore } from 'reactfire';
+import { useMessaging, useUser, useFirestore, useAnalytics } from 'reactfire';
 import { useNotifications } from 'modules/notification';
 import { USERS_COLLECTION } from 'constants/collections';
 
@@ -11,6 +11,7 @@ let messagingInitialized = false;
 export default function useSetupMessaging() {
   const messaging = useMessaging();
   const firestore = useFirestore();
+  const analytics = useAnalytics();
   const { FieldValue } = useFirestore;
   const user = useUser();
   const { showSuccess } = useNotifications();
@@ -100,7 +101,7 @@ export default function useSetupMessaging() {
       .then(() => getTokenAndWriteToProfile(messaging))
       .catch((err) => {
         console.error('Unable to get permission to notify: ', err); // eslint-disable-line no-console
-        return Promise.reject(err);
+        analytics.logEvent('notification-no-permission', err);
       });
   }
   return { initializeMessaging };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1840,6 +1840,17 @@
     "@sentry/utils" "5.15.4"
     tslib "^1.9.3"
 
+"@sentry/cli@^1.52.3":
+  version "1.52.3"
+  resolved "https://registry.yarnpkg.com/@sentry/cli/-/cli-1.52.3.tgz#270ed167c7dae2f85eb4622ad3a4ec12ab67e6d2"
+  integrity sha512-QOSIg5hxAEa6v6H7oEeF6A/Rpa0wloMhbu0Qed6zHv3lyoqf0Z34Kq2jCXdqGsOE3IzkO+3CNy81F6361j5TKg==
+  dependencies:
+    https-proxy-agent "^5.0.0"
+    mkdirp "^0.5.5"
+    node-fetch "^2.6.0"
+    progress "^2.0.3"
+    proxy-from-env "^1.1.0"
+
 "@sentry/core@5.15.4":
   version "5.15.4"
   resolved "https://registry.yarnpkg.com/@sentry/core/-/core-5.15.4.tgz#08b617e093a636168be5aebad141d1f744217085"
@@ -9682,7 +9693,7 @@ mixin-object@^2.0.1:
     for-in "^0.1.3"
     is-extendable "^0.1.1"
 
-"mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@^0.5.3, mkdirp@^0.5.4, mkdirp@~0.5.1:
+"mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@^0.5.3, mkdirp@^0.5.4, mkdirp@^0.5.5, mkdirp@~0.5.1:
   version "0.5.5"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.5.tgz#d91cefd62d1436ca0f41620e251288d420099def"
   integrity sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==
@@ -11470,6 +11481,11 @@ proxy-addr@~2.0.5:
   dependencies:
     forwarded "~0.1.2"
     ipaddr.js "1.9.1"
+
+proxy-from-env@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
+  integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
 
 prr@~1.0.1:
   version "1.0.1"


### PR DESCRIPTION


### Description
* Fixes Sentry error by switching to an analytics event instead of throwing an error (being picked up by Sentry)

### Relevant Tickets (Please add `closes`, `refs`, etc)

- closes #101

### Screenshots (if appropriate)
